### PR TITLE
Removed versionnumber

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
   "name": "paynl/magento2-plugin",
   "description": "Pay.nl Magento2 Payment methods",
   "type": "magento2-module",
-  "version": "1.2.9",
   "require": {
     "php": "~5.5.22|~5.6.0|7.0.2|7.0.4|~7.0.6|~7.1.0",
     "magento/module-sales": "100 - 101",


### PR DESCRIPTION
Version number is not required in composer.json. If you create a new release in Github, it is automatically picked up by Packagist.