### PR TITLE
Added fix for unmapped JSON payloads

### DIFF
--- a/Controller/Checkout/Exchange.php
+++ b/Controller/Checkout/Exchange.php
@@ -12,6 +12,7 @@ use Magento\Sales\Model\Order;
 use Magento\Sales\Model\Order\Payment\Interceptor;
 use Magento\Sales\Model\OrderRepository;
 use Paynl\Payment\Controller\CsrfAwareActionInterface;
+use Paynl\Payment\Controller\PayAction;
 use Paynl\Result\Transaction\Transaction;
 
 
@@ -21,7 +22,7 @@ use Paynl\Result\Transaction\Transaction;
  *
  * @author Andy Pieters <andy@pay.nl>
  */
-class Exchange extends \Magento\Framework\App\Action\Action implements CsrfAwareActionInterface
+class Exchange extends PayAction implements CsrfAwareActionInterface
 //    implements CsrfAwareActionInterface
 {
     /**

--- a/Controller/Checkout/Finish.php
+++ b/Controller/Checkout/Finish.php
@@ -11,6 +11,7 @@ use Magento\Framework\App\Action\Context;
 use Magento\Quote\Model\QuoteRepository;
 use Magento\Sales\Model\Order;
 use Magento\Sales\Model\OrderRepository;
+use Paynl\Payment\Controller\PayAction;
 use Paynl\Payment\Model\Config;
 use Psr\Log\LoggerInterface;
 
@@ -19,7 +20,7 @@ use Psr\Log\LoggerInterface;
  *
  * @author Andy Pieters <andy@pay.nl>
  */
-class Finish extends Action
+class Finish extends PayAction
 {
     /**
      *

--- a/Controller/Checkout/Redirect.php
+++ b/Controller/Checkout/Redirect.php
@@ -9,13 +9,14 @@ use Magento\Payment\Helper\Data as PaymentHelper;
 use Magento\Quote\Model\QuoteRepository;
 use Magento\Sales\Model\OrderRepository;
 use Paynl\Error\Error;
+use Paynl\Payment\Controller\PayAction;
 
 /**
  * Description of Redirect
  *
  * @author Andy Pieters <andy@pay.nl>
  */
-class Redirect extends \Magento\Framework\App\Action\Action
+class Redirect extends PayAction
 {
     /**
      * @var \Paynl\Payment\Model\Config

--- a/Controller/PayAction.php
+++ b/Controller/PayAction.php
@@ -20,7 +20,7 @@ abstract class PayAction extends \Magento\Framework\App\Action\Action
         if ($request->isPost() && count($request->getParams()) <= 0) {
             $jsonRequest = json_decode($request->getContent(), true);
 
-            if (count($jsonRequest) > 0) {
+            if (is_array($jsonRequest)) {
                 $request->setParams($jsonRequest);
             }
         }

--- a/Controller/PayAction.php
+++ b/Controller/PayAction.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Copyright © 2020 Pay.nl All rights reserved.
+ */
+
+namespace Paynl\Payment\Controller;
+
+/**
+ * Class PayAction
+ * @package Paynl\Payment\Controller
+ */
+abstract class PayAction extends \Magento\Framework\App\Action\Action
+{
+    /**
+     * @return \Magento\Framework\App\RequestInterface
+     */
+    public function getRequest()
+    {
+        $request = parent::getRequest();
+        if ($request->isPost() && count($request->getParams()) <= 0) {
+            $jsonRequest = json_decode($request->getContent(), true);
+
+            if (count($jsonRequest) > 0) {
+                $request->setParams($jsonRequest);
+            }
+        }
+
+        return $request;
+    }
+}


### PR DESCRIPTION
I cannot seem to get Magento to map the JSON payload to `request->getParams()`.
Therefore I wrote this fix that reads the body of the POST request and checks if it is JSON readable, then sets the JSON values to the parameters using `setParams`.