### PR TITLE
No paymentmethods in checkout are shown - bug in selecting default payment method.

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/default.js
+++ b/view/frontend/web/js/view/payment/method-renderer/default.js
@@ -22,9 +22,15 @@ define(
             billink_agree: null,
             initialize: function () {
                 this._super();
-                if (!quote.paymentMethod() && window.checkoutConfig.payment.defaultpaymentoption[this.item.method]) {
+
+                var defaultPaymentMethod = window.checkoutConfig.payment.defaultpaymentoption;
+                if (!quote.paymentMethod() &&
+                    typeof defaultPaymentMethod !== 'undefined' &&
+                    typeof defaultPaymentMethod[this.item.method] !== 'undefined' &&
+                    defaultPaymentMethod[this.item.method])  {
                     this.selectPaymentMethod();
                 }
+
                 return this;
             },
             isVisible:function() {


### PR DESCRIPTION
Fixed bug in checkout - no payment methods shown when no default payment method is selected. window.checkoutConfig.payment.defaultpaymentoption is undefined.