### PR TITLE
Save redirect url to payment additional information

### DIFF
--- a/Model/Paymentmethod/PaymentMethod.php
+++ b/Model/Paymentmethod/PaymentMethod.php
@@ -255,9 +255,12 @@ abstract class PaymentMethod extends AbstractMethod
         if ($holded) {
             $order->hold();
         }
+
+        $redirectUrl = $transaction->getRedirectUrl();
+        $order->getPayment()->setAdditionalInformation('payNLRedirectUrl', $redirectUrl);
         $this->orderRepository->save($order);
 
-        return $transaction->getRedirectUrl();
+        return $redirectUrl;
     }
 
     protected function doStartTransaction(Order $order)


### PR DESCRIPTION
PayNL use redirects to make payments. 

When the customer close the payment window accidentally, and they will loss the payment information.

By saving the redirect information, we can allow the user to continue making payments before the payment expire, without having to reorder.