### PR TITLE
Fix issue with pin terminals returning wrong type

### DIFF
--- a/Model/Config/Source/PinTerminals.php
+++ b/Model/Config/Source/PinTerminals.php
@@ -83,6 +83,10 @@ class PinTerminals implements ArrayInterface
                     $terminals = \Paynl\Instore::getAllTerminals();
                     $terminals = $terminals->getList();
 
+                    if (!is_array($terminals)) {
+                        $terminals = [];
+                    }
+                    
                     foreach ($terminals as $terminal) {
                         $terminal['visibleName'] = $terminal['name'];
                         array_push($terminalArr, $terminal);


### PR DESCRIPTION
Fixes:

Invalid argument supplied for foreach() where array is expected and string is returned