### PR TITLE
Fix issue #174

### DIFF
--- a/etc/acl.xml
+++ b/etc/acl.xml
@@ -5,6 +5,7 @@
             <resource id="Magento_Backend::admin">
                 <resource id="Paynl_Payment::acl" title="Pay." sortOrder="1">
                     <resource id="Paynl_Payment::logs" title="Download logs" sortOrder="1" />
+                    <resource id="Paynl_Payment::config" title="Configure Pay." sortOrder="1" />
                 </resource>
             </resource>
         </resources>


### PR DESCRIPTION
This will add the ACL option for the configuration so that you can modify the ACL to access the configuration of the Pay. module when not using full access roles.