### PR TITLE
Fix PHP 8.2 Deprication exception

### DIFF
--- a/Observer/SubtractInventoryObserver.php
+++ b/Observer/SubtractInventoryObserver.php
@@ -19,6 +19,12 @@ class SubtractInventoryObserver implements ObserverInterface
      */
     protected $itemsForReindex;
 
+
+    /**
+     * @var \Magento\CatalogInventory\Model\Indexer\Stock\Processor
+     */
+    protected stockIndexerProcessor;
+
     /**
      * SubtractInventoryObserver constructor.
      * @param StockManagementInterface $stockManagement


### PR DESCRIPTION
Creation of dynamic property Paynl\Payment\Observer\SubtractInventoryObserver::$stockIndexerProcessor is deprecated has been deprecated since