### PR TITLE
Fix terminal in use

### DIFF
--- a/Model/Paymentmethod/Instore.php
+++ b/Model/Paymentmethod/Instore.php
@@ -76,16 +76,14 @@ class Instore extends PaymentMethod
 
             $transaction = (new PayPaymentCreate($order, $this))->create();
 
-            $instorePayment = \Paynl\Instore::payment(['transactionId' => $transaction->getTransactionId(), 'terminalId' => $terminalId]);
-
             $additionalData['transactionId'] = $transaction->getTransactionId();
-            $additionalData['terminal_hash'] = $instorePayment->getHash();
+            $additionalData['terminal_hash'] = $transaction->getData()['terminal']['hash'];
             $additionalData['payment_option'] = $terminalId;
 
             $order->getPayment()->setAdditionalInformation($additionalData);
             $order->save();
 
-            $url = $instorePayment->getRedirectUrl();
+            $url = $transaction->getRedirectUrl();
         } catch (\Exception $e) {
             $this->payHelper->logCritical($e->getMessage(), [], $store);
 


### PR DESCRIPTION
Because `(new PayPaymentCreate($order, $this))->create()` already creates a new transaction and triggers the pin terminal the subsequent
`\Paynl\Instore::payment(['transactionId' => $transaction->getTransactionId(), 'terminalId' => $terminalId])`
fails with the message: PAY-9206 - Terminal in use

However this 2nd payment call does not seem necessary, not even to get all required data since transaction start already returns the following data:
```
{
    "request": {
        "result": "1",
        "errorId": "",
        "errorMessage": ""
    },
    "endUser": {
        "blacklist": "0"
    },
    "transaction": {
        "transactionId": "XXXXXXXXXXX",
        "paymentURL": "https:\/\/safe.pay.nl\/pin\/xxxxxxxxxxxxxxxxxxx\/NL",
        "popupAllowed": "0",
        "paymentReference": "0000 0000 0000 0000"
    },
    "terminal": {
        "hash": "0000000000000aaaaaaaaaaaaaaaa",
        "statusUrl": "https:\/\/pin.pay.nl:9002\/api\/status?hash=0000000000000aaaaaaaaaaaaaaaa&timeout=5",
        "cancelUrl": "https:\/\/pin.pay.nl:9002\/api\/cancel?hash=0000000000000aaaaaaaaaaaaaaaa"
    }
}
```