### PR TITLE
fix missing invoice city bug

### DIFF
--- a/Model/PayPaymentCreate.php
+++ b/Model/PayPaymentCreate.php
@@ -410,7 +410,7 @@ class PayPaymentCreate
             $invoiceAddress['streetName'] = mb_substr($arrAddress[0] ?? '', 0, 128);
             $invoiceAddress['houseNumber'] = mb_substr($arrAddress[1] ?? '', 0, 10);
             $invoiceAddress['zipCode'] = mb_substr($arrBillingAddress['postcode'] ?? '', 0, 24);
-            $shippingAddress['city'] = mb_substr($arrBillingAddress['city'] ?? '', 0, 40);
+            $invoiceAddress['city'] = mb_substr($arrBillingAddress['city'] ?? '', 0, 40);
             $invoiceAddress['country'] = $arrBillingAddress['country_id'];
         }
 


### PR DESCRIPTION
Fix wrong array name $shippingAddress to fix bug that invoice city is not being send to the API.