### PR TITLE
Bugfix Email templates

### DIFF
--- a/view/frontend/email/paylink_email.html
+++ b/view/frontend/email/paylink_email.html
@@ -1,25 +1,27 @@
 <!--@subject {{var subject}}  @-->
 <!--@vars
-{"store url=\"\"":"Store Url",
-"skin url=\"images/logo_email.gif\" _area='frontend'":"Email Logo Image"},
-"var formattedBillingAddress|raw":"Billing Address",
-"var email_customer_note|escape|nl2br":"Email Order Note",
-"var order.increment_id":"Order Id",
-"layout handle=\"sales_email_order_items\" order=$order area=\"frontend\"":"Order Items Grid",
-"var payment_html|raw":"Payment Details",
-"var formattedShippingAddress|raw":"Shipping Address",
-"var order.shipping_description":"Shipping Description",
-"var shipping_msg":"Shipping message",
-"var created_at_formatted":"Order Created At (datetime)",
-"var store.frontend_name":"Store Frontend Name",
-"var store_phone":"Store Phone",
-"var store_email":"Store Email",
-"var store_hours":"Store Hours",
-"var this.getUrl($store,'customer/account/',[_nosid:1])":"Customer Account URL",
-"var is_not_virtual":"Order Type",
-"var order":"Order",
-"var customer_name":"Customer Name"
-"var show_order_in_mail":"show Order",
+{
+    "store url=\"\"":"Store Url",
+    "skin url=\"images/logo_email.gif\" _area='frontend'":"Email Logo Image",
+    "var formattedBillingAddress|raw":"Billing Address",
+    "var email_customer_note|escape|nl2br":"Email Order Note",
+    "var order.increment_id":"Order Id",
+    "layout handle=\"sales_email_order_items\" order=$order area=\"frontend\"":"Order Items Grid",
+    "var payment_html|raw":"Payment Details",
+    "var formattedShippingAddress|raw":"Shipping Address",
+    "var order.shipping_description":"Shipping Description",
+    "var shipping_msg":"Shipping message",
+    "var created_at_formatted":"Order Created At (datetime)",
+    "var store.frontend_name":"Store Frontend Name",
+    "var store_phone":"Store Phone",
+    "var store_email":"Store Email",
+    "var store_hours":"Store Hours",
+    "var this.getUrl($store,'customer/account/',[_nosid:1])":"Customer Account URL",
+    "var is_not_virtual":"Order Type",
+    "var order":"Order",
+    "var customer_name":"Customer Name",
+    "var show_order_in_mail":"Show Order"
+}
 @-->
 <!--@styles
 body,td {
@@ -28,7 +30,7 @@ body,td {
     font-style: normal;
     font-weight: 400;
     line-height: 1.42857143;
-    font-size: 14px; 
+    font-size: 14px;
 }
 @-->
 

--- a/view/frontend/email/paylink_email_order.html
+++ b/view/frontend/email/paylink_email_order.html
@@ -1,25 +1,27 @@
 <!--@subject {{var subject}}  @-->
 <!--@vars
-{"store url=\"\"":"Store Url",
-"skin url=\"images/logo_email.gif\" _area='frontend'":"Email Logo Image"},
-"var formattedBillingAddress|raw":"Billing Address",
-"var email_customer_note|escape|nl2br":"Email Order Note",
-"var order.increment_id":"Order Id",
-"layout handle=\"sales_email_order_items\" order=$order area=\"frontend\"":"Order Items Grid",
-"var payment_html|raw":"Payment Details",
-"var formattedShippingAddress|raw":"Shipping Address",
-"var order.shipping_description":"Shipping Description",
-"var shipping_msg":"Shipping message",
-"var created_at_formatted":"Order Created At (datetime)",
-"var store.frontend_name":"Store Frontend Name",
-"var store_phone":"Store Phone",
-"var store_email":"Store Email",
-"var store_hours":"Store Hours",
-"var this.getUrl($store,'customer/account/',[_nosid:1])":"Customer Account URL",
-"var is_not_virtual":"Order Type",
-"var order":"Order",
-"var customer_name":"Customer Name"
-"var show_order_in_mail":"show Order",
+{
+    "store url=\"\"":"Store Url",
+    "skin url=\"images/logo_email.gif\" _area='frontend'":"Email Logo Image",
+    "var formattedBillingAddress|raw":"Billing Address",
+    "var email_customer_note|escape|nl2br":"Email Order Note",
+    "var order.increment_id":"Order Id",
+    "layout handle=\"sales_email_order_items\" order=$order area=\"frontend\"":"Order Items Grid",
+    "var payment_html|raw":"Payment Details",
+    "var formattedShippingAddress|raw":"Shipping Address",
+    "var order.shipping_description":"Shipping Description",
+    "var shipping_msg":"Shipping message",
+    "var created_at_formatted":"Order Created At (datetime)",
+    "var store.frontend_name":"Store Frontend Name",
+    "var store_phone":"Store Phone",
+    "var store_email":"Store Email",
+    "var store_hours":"Store Hours",
+    "var this.getUrl($store,'customer/account/',[_nosid:1])":"Customer Account URL",
+    "var is_not_virtual":"Order Type",
+    "var order":"Order",
+    "var customer_name":"Customer Name",
+    "var show_order_in_mail":"show Order"
+}
 @-->
 <!--@styles
 body,td {
@@ -28,7 +30,7 @@ body,td {
     font-style: normal;
     font-weight: 400;
     line-height: 1.42857143;
-    font-size: 14px; 
+    font-size: 14px;
 }
 @-->
 
@@ -38,7 +40,7 @@ body,td {
 {{var body|raw}}
 
 <br/>
-<table style="width:100%;">    
+<table style="width:100%;">
     <tr class="email-summary">
         <td>
             <h1>{{trans "Your Order"}} #{{var order_increment_id}}</h1>
@@ -77,13 +79,13 @@ body,td {
                     {{depend is_not_virtual}}
                     <td class="method-info">
                         <h3>{{trans "Shipping Method"}}</h3>
-                        <p>{{var order.shipping_description}}</p>                        
-                        <p>{{var shipping_msg}}</p>                        
+                        <p>{{var order.shipping_description}}</p>
+                        <p>{{var shipping_msg}}</p>
                     </td>
                     {{/depend}}
                 </tr>
             </table>
-            {{layout handle="sales_email_order_items" order=$order order_id=$order_id area="frontend"}}        
+            {{layout handle="sales_email_order_items" order=$order order_id=$order_id area="frontend"}}
         </td>
     </tr>
 </table>


### PR DESCRIPTION
This PR corrects the @vars section in the email template by properly formatting it as a JSON structure. The issue has been present since commit [c576f85](https://github.com/paynl/magento2-plugin/commit/c576f850027f09dc8ef3e31291e5fdb4d064acb9), made 4 years ago.

Fix:
Reformated `@vars` section to ensure proper serialization and deserialization in Magento.
Testing:
Verified that email templates load and send correctly without errors after the fix.

![](https://t6651913.p.clickup-attachments.com/t6651913/eb135270-ed5c-45c8-995c-511f9ea9d1a8/image.png)

Stack trace:
/var/www/html/vendor/magento/framework/Serialize/Serializer/Json.php:Unable to unserialize value. Error: Syntax error

Stack trace:
/var/www/html/vendor/magento/module-email/Model/Template.php
Args: {"store url=\"\"":"Store Url","skin url=\"images/logo_email.gif\" _area='frontend'":"Email Logo Image"},"var formattedBillingAddress|raw":"Billing Address","var email_customer_note|escape|nl2br":"Email Order Note","var order.increment_id":"Order Id","layout handle=\"sales_email_order_items\" order=$order area=\"frontend\"":"Order Items Grid","var payment_html|raw":"Payment Details","var formattedShippingAddress|raw":"Shipping Address","var order.shipping_description":"Shipping Description","var shipping_msg":"Shipping message","var created_at_formatted":"Order Created At (datetime)","var store.frontend_name":"Store Frontend Name","var store_phone":"Store Phone","var store_email":"Store Email","var store_hours":"Store Hours","var this.getUrl($store,'customer/account/',[_nosid:1])":"Customer Account URL","var is_not_virtual":"Order Type","var order":"Order","var customer_name":"Customer Name""var show_order_in_mail":"show Order",



