### PR TITLE
Capitalize M in class reference

### DIFF
--- a/Controller/Adminhtml/Order/CardRefund.php
+++ b/Controller/Adminhtml/Order/CardRefund.php
@@ -96,7 +96,7 @@ class CardRefund extends \Magento\Backend\App\Action implements CsrfAwareActionI
             $order->save();
 
             $methodInstance = $this->paymentHelper->getMethodInstance('paynl_payment_cardrefund');
-            if ($methodInstance instanceof \Paynl\Payment\Model\Paymentmethod\Paymentmethod) {
+            if ($methodInstance instanceof \Paynl\Payment\Model\Paymentmethod\PaymentMethod) {
                 $redirectUrl = $methodInstance->startTransaction($order, true);
             }
         } catch (\Exception $e) {

--- a/Controller/Adminhtml/Order/Instore.php
+++ b/Controller/Adminhtml/Order/Instore.php
@@ -89,7 +89,7 @@ class Instore extends \Magento\Backend\App\Action implements CsrfAwareActionInte
             $payment->setAdditionalInformation('returnUrl', $returnUrl);
 
             $methodInstance = $this->paymentHelper->getMethodInstance($payment->getMethod());
-            if ($methodInstance instanceof \Paynl\Payment\Model\Paymentmethod\Paymentmethod) {
+            if ($methodInstance instanceof \Paynl\Payment\Model\Paymentmethod\PaymentMethod) {
                 $redirectUrl = $methodInstance->startTransaction($order, true);
             }
         } catch (\Exception $e) {

--- a/Controller/Checkout/Redirect.php
+++ b/Controller/Checkout/Redirect.php
@@ -92,7 +92,7 @@ class Redirect extends PayAction
             }
 
             $methodInstance = $this->paymentHelper->getMethodInstance($payment->getMethod());
-            if ($methodInstance instanceof \Paynl\Payment\Model\Paymentmethod\Paymentmethod) {
+            if ($methodInstance instanceof \Paynl\Payment\Model\Paymentmethod\PaymentMethod) {
                 $this->payHelper->logNotice('Start new payment for order ' . $order->getId() . '. PayProfileId: ' . $methodInstance->getPaymentOptionId(), array(), $order->getStore());
                 $redirectUrl = $methodInstance->startTransaction($order);
                 $this->getResponse()->setNoCacheHeaders();

--- a/Model/PayPaymentCreateFastCheckout.php
+++ b/Model/PayPaymentCreateFastCheckout.php
@@ -27,7 +27,7 @@ class PayPaymentCreateFastCheckout extends PayPaymentCreate
     private $reservedOrderId = '';
 
     /**
-     * @param \Paynl\Payment\Model\Paymentmethod\Paymentmethod $methodInstance
+     * @param \Paynl\Payment\Model\Paymentmethod\PaymentMethod $methodInstance
      * @param string $amount Amount to start fastCheckout with
      * @param array $products Procucts to buy with fastCheckout
      * @param string $baseUrl

--- a/Observer/InvoiceSaveCommitAfter.php
+++ b/Observer/InvoiceSaveCommitAfter.php
@@ -64,7 +64,7 @@ class InvoiceSaveCommitAfter implements ObserverInterface
         $order = $invoice->getOrder();
         $payment = $order->getPayment();
         $methodInstance = $payment->getMethodInstance();
-        if ($methodInstance instanceof \Paynl\Payment\Model\Paymentmethod\Paymentmethod) {
+        if ($methodInstance instanceof \Paynl\Payment\Model\Paymentmethod\PaymentMethod) {
             $postdata = $this->_request->getPost();
             if (!empty($postdata['invoice']['capture_case']) && $postdata['invoice']['capture_case'] == "online" && $order->getState() == Order::STATE_PROCESSING) {
                 $this->config->setStore($order->getStore());

--- a/Observer/OrderCancelAfter.php
+++ b/Observer/OrderCancelAfter.php
@@ -44,7 +44,7 @@ class OrderCancelAfter implements ObserverInterface
         $order = $observer->getEvent()->getOrder();
         $payment = $order->getPayment();
         $methodInstance = $payment->getMethodInstance();
-        if ($methodInstance instanceof \Paynl\Payment\Model\Paymentmethod\Paymentmethod) {
+        if ($methodInstance instanceof \Paynl\Payment\Model\Paymentmethod\PaymentMethod) {
             $this->config->setStore($order->getStore());
             if ($this->config->autoVoidEnabled()) {
                 if ($order->getState() == Order::STATE_CANCELED && !$order->hasInvoices()) {

--- a/Observer/ShipmentSaveAfter.php
+++ b/Observer/ShipmentSaveAfter.php
@@ -63,7 +63,7 @@ class ShipmentSaveAfter implements ObserverInterface
         $order = $observer->getEvent()->getShipment()->getOrder();
         $payment = $order->getPayment();
         $methodInstance = $payment->getMethodInstance();
-        if ($methodInstance instanceof \Paynl\Payment\Model\Paymentmethod\Paymentmethod) {
+        if ($methodInstance instanceof \Paynl\Payment\Model\Paymentmethod\PaymentMethod) {
             $this->config->setStore($order->getStore());
 
             if ($this->config->autoCaptureEnabled()) {

--- a/Observer/SubtractInventoryObserver.php
+++ b/Observer/SubtractInventoryObserver.php
@@ -49,7 +49,7 @@ class SubtractInventoryObserver implements ObserverInterface
 
         $payment = $order->getPayment();
         $methodInstance = $payment->getMethodInstance();
-        if ($methodInstance instanceof \Paynl\Payment\Model\Paymentmethod\Paymentmethod) {
+        if ($methodInstance instanceof \Paynl\Payment\Model\Paymentmethod\PaymentMethod) {
             $productQty = $observer->getEvent()->getProductQty();
 
             if ($order->getInventoryProcessed()) {


### PR DESCRIPTION
The class `\Paynl\Payment\Model\Paymentmethod\PaymentMethod` is spelled with `Method` with capital M - in both the class name and the filename. However, various other classes are referring to this class with lowercase M instead: `\Paynl\Payment\Model\Paymentmethod\Paymentmethod`. In my case, this led into PHP warnings under PHP 8.4 when the composer autoloader was optimized. This PR makes sure the right classname is used.