### PR TITLE
Lowered some logging types

### DIFF
--- a/Controller/Checkout/Redirect.php
+++ b/Controller/Checkout/Redirect.php
@@ -93,7 +93,7 @@ class Redirect extends PayAction
 
             $methodInstance = $this->paymentHelper->getMethodInstance($payment->getMethod());
             if ($methodInstance instanceof \Paynl\Payment\Model\Paymentmethod\Paymentmethod) {
-                $this->payHelper->logNotice('Start new payment for order ' . $order->getId() . '. PayProfileId: ' . $methodInstance->getPaymentOptionId(), array(), $order->getStore());
+                $this->payHelper->logInfo('Start new payment for order ' . $order->getId() . '. PayProfileId: ' . $methodInstance->getPaymentOptionId(), array(), $order->getStore());
                 if ($this->config->restoreQuote()) {
                     $this->_getCheckoutSession()->restoreQuote();
                 }

--- a/Observer/InvoiceSaveCommitAfter.php
+++ b/Observer/InvoiceSaveCommitAfter.php
@@ -71,7 +71,7 @@ class InvoiceSaveCommitAfter implements ObserverInterface
                 $paymentMethod = $order->getPayment()->getMethod();
                 $customStatus = $this->config->getPaidStatus($paymentMethod);
                 if (!empty($customStatus)) {
-                    $this->payHelper->logNotice('PAY.: Updating order status from ' . $order->getStatus() . ' to ' . $customStatus, [], $order->getStore());
+                    $this->payHelper->logInfo('PAY.: Updating order status from ' . $order->getStatus() . ' to ' . $customStatus, [], $order->getStore());
                     $order->setStatus($customStatus)->save();
                 }
             }


### PR DESCRIPTION
Since updating Sentry we're getting these reported as errors due to them being logged as notices instead of info.
This PR updates these logs to the right logging level (`logDebug` would also be acceptable for these, though i suspect there's a reason they were being logged a higher level than debug)