### PR TITLE
Fix #224: Prevent str_replace() deprecation by handling null $subject

### DIFF
--- a/Observer/ShipmentSaveAfter.php
+++ b/Observer/ShipmentSaveAfter.php
@@ -71,7 +71,7 @@ class ShipmentSaveAfter implements ObserverInterface
 
                 if ($order->getState() == Order::STATE_PROCESSING && $invoiceCheck) {
                     $data = $order->getPayment()->getData();
-                    $payOrderId = $data['last_trans_id'] ?? null;
+                    $payOrderId = $data['last_trans_id'] ?? '';
                     $payOrderId = str_replace('-capture', '', $payOrderId);
 
                     if (!empty($payOrderId)) {


### PR DESCRIPTION
Fix for https://github.com/paynl/magento2-plugin/issues/224

`str_replace()` should only be called with a string or array as the third argument to avoid deprecation errors

### Solution:
Ensure that the third argument of `str_replace()` is never null. For example:
```
$payOrderId = $data['last_trans_id'] ?? '';
$payOrderId = str_replace('-capture', '', $payOrderId);
```