### PR TITLE
Fix error when terminals arent saved yet

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -26,6 +26,7 @@
                 <follow_payment_method>1</follow_payment_method>
                 <sdk_caching>1</sdk_caching>
                 <multicore><![CDATA[https://connect.pay.nl]]></multicore>
+                <terminals>[]</terminals>
             </paynl>
             <paynl_payment_paylink>
                 <active>0</active>


### PR DESCRIPTION
After updating to V4 You will get errors on the cart page concering passing null to json_decode.
This fix creates a default value of [] in case `terminals` is null, until a trigger to saveTerminalsToConfig has occurred where the column is properly populated.