### PR TITLE
Call startSetup before endSetup

### DIFF
--- a/Setup/Patch/Data/AddPaymentMethodAttribute.php
+++ b/Setup/Patch/Data/AddPaymentMethodAttribute.php
@@ -25,7 +25,9 @@ class AddPaymentMethodAttribute implements DataPatchInterface, PatchRevertableIn
     {
         $setup = $this->moduleDataSetup;
         $eavSetup = $this->eavSetupFactory->create(['setup' => $setup]);
-
+        
+        $setup->startSetup();
+        
         $eavSetup->addAttribute(Product::ENTITY, 'paynl_product_allowed_payment_methods', [
             'type' => 'text',
             'label' => 'Allowed Pay. Payment Methods',


### PR DESCRIPTION
When startSetup is not called and endSetup is the following causes a deprecation error:

https://github.com/magento/magento2/blob/b5e99d20ee50210caaf1672d8f26060d04767556/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php#L3127

Due to `$this->mysqlversion` being null