### PR TITLE
Update PayNL with Table Prefix catch.

### DIFF
--- a/Controller/Process/Capture.php
+++ b/Controller/Process/Capture.php
@@ -66,7 +66,7 @@ class Capture extends Action implements CsrfAwareActionInterface
     {
         $connection = $this->resourceConnection->getConnection();
         $select = $connection->select()
-            ->from($connection->getTableName('core_config_data'), ['value'])
+            ->from($this->resourceConnection->getTableName('core_config_data'), ['value'])
             ->where('path = ?', 'payment/paynl/process_secret')
             ->where('scope = ?', $scope)
             ->where('scope_id = ?', $scopeId)

--- a/Model/Config/Source/MultiCoreOptions.php
+++ b/Model/Config/Source/MultiCoreOptions.php
@@ -53,7 +53,7 @@ class MultiCoreOptions implements ArrayInterface
     {
         $connection = $this->resourceConnection->getConnection();
         $select = $connection->select()
-            ->from('core_config_data', ['value'])
+            ->from($this->resourceConnection->getTableName('core_config_data'), ['value'])
             ->where('path = ?', 'payment/paynl/cores')
             ->where('scope = ?', $scope)
             ->where('scope_id = ?', $scopeId)


### PR DESCRIPTION
Table Prefix was not taken in. 
If a Magento install has a custom table prefix, the extension crashes on core_config_data.
This fix fixes it.